### PR TITLE
Allow newer `flutter_lints` versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
       flutter_test:
             sdk: flutter
-      flutter_lints: ^1.0.0
+      flutter_lints: '>=1.0.0'
       build_runner: ^2.1.4
       json_serializable: ^6.0.0
 flutter:


### PR DESCRIPTION
This is just a small tweak in `pubspec.yaml`.

Once this change is implemented, developers who use this plugin won't be prevented from using new linting features.