### PR TITLE
fix: Fix use incorrect length value in RtmClientImplOverride.publish/StreamChannelImpl.publishTopicMessage

### DIFF
--- a/lib/src/bindings/agora_rtm_client_impl_override.dart
+++ b/lib/src/bindings/agora_rtm_client_impl_override.dart
@@ -228,10 +228,11 @@ class RtmClientImplOverride extends rtmc_binding.RtmClientImpl {
       required String message,
       required int length,
       required PublishOptions option}) async {
+    final messageUint8List = Uint8List.fromList(utf8.encode(message));
     return publishBinaryMessage(
         channelName: channelName,
-        message: Uint8List.fromList(utf8.encode(message)),
-        length: length,
+        message: messageUint8List,
+        length: messageUint8List.length,
         option: option);
   }
 }

--- a/lib/src/bindings/agora_stream_channel_impl_override.dart
+++ b/lib/src/bindings/agora_stream_channel_impl_override.dart
@@ -44,10 +44,11 @@ class StreamChannelImpl extends sci_binding.StreamChannelImpl
       required String message,
       required int length,
       required TopicMessageOptions option}) async {
+    final messageUint8List = Uint8List.fromList(utf8.encode(message));
     return publishBinaryMessage(
         topic: topic,
-        message: Uint8List.fromList(utf8.encode(message)),
-        length: length,
+        message: messageUint8List,
+        length: messageUint8List.length,
         option: option);
   }
 
@@ -57,10 +58,11 @@ class StreamChannelImpl extends sci_binding.StreamChannelImpl
       required String message,
       required int length,
       required TopicMessageOptions option}) {
+    final messageUint8List = Uint8List.fromList(utf8.encode(message));
     return publishBinaryMessage(
         topic: topic,
-        message: Uint8List.fromList(utf8.encode(message)),
-        length: length,
+        message: messageUint8List,
+        length: messageUint8List.length,
         option: option);
   }
 }

--- a/lib/src/impl/agora_rtm_client_impl_override.dart
+++ b/lib/src/impl/agora_rtm_client_impl_override.dart
@@ -222,17 +222,6 @@ class RtmClientImplOverride extends rtm_client_impl.RtmClientImpl {
       String channelName, String message,
       {RtmChannelType channelType = RtmChannelType.message,
       String? customType}) async {
-    // final option = PublishOptions(
-    //     channelType: channelType,
-    //     messageType: RtmMessageType.string,
-    //     customType: customType);
-    // final requestId = await nativeBindingRtmClientImpl.publish(
-    //     channelName: channelName,
-    //     message: message,
-    //     length: message.length,
-    //     option: option);
-    // return rtmResultHandler.request(requestId);
-
     final option = PublishOptions(
         channelType: channelType,
         messageType: RtmMessageType.string,
@@ -260,17 +249,6 @@ class RtmClientImplOverride extends rtm_client_impl.RtmClientImpl {
       String channelName, Uint8List message,
       {RtmChannelType channelType = RtmChannelType.message,
       String? customType}) async {
-    // final option = PublishOptions(
-    //     channelType: channelType,
-    //     messageType: RtmMessageType.binary,
-    //     customType: customType);
-    // final requestId = await nativeBindingRtmClientImpl.publishBinaryMessage(
-    //     channelName: channelName,
-    //     message: message,
-    //     length: message.length,
-    //     option: option);
-    // return rtmResultHandler.request(requestId);
-
     final option = PublishOptions(
         channelType: channelType,
         messageType: RtmMessageType.binary,

--- a/test_shard/integration_test_app/test/agora_rtm_client_impl_override_test.dart
+++ b/test_shard/integration_test_app/test/agora_rtm_client_impl_override_test.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import 'dart:typed_data' show Uint8List;
+
+import 'package:agora_rtm/agora_rtm.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:agora_rtm/src/bindings/agora_rtm_client_impl_override.dart'
+    as agora_rtm_client_impl;
+
+import 'fake_iris_method_channel.dart';
+
+void main() {
+  test('RtmClientImplOverride.publish', () {
+    FakeIrisMethodChannel irisMethodChannel = FakeIrisMethodChannel();
+    agora_rtm_client_impl.RtmClientImplOverride rtmClientImplOverride =
+        agora_rtm_client_impl.RtmClientImplOverride.create(irisMethodChannel);
+    const message = 'hello';
+    final messageUint8List = Uint8List.fromList(utf8.encode(message));
+
+    rtmClientImplOverride.publish(
+        channelName: '123',
+        message: message,
+        length: 5,
+        option: const PublishOptions());
+
+    final methodCall = irisMethodChannel.methodCallQueue[0];
+    final paramsMap = jsonDecode(methodCall.params);
+    expect(paramsMap['length'], messageUint8List.length);
+    expect(methodCall.buffers![0], messageUint8List);
+  });
+
+  test('RtmClientImplOverride.publishBinaryMessage', () {
+    FakeIrisMethodChannel irisMethodChannel = FakeIrisMethodChannel();
+    agora_rtm_client_impl.RtmClientImplOverride rtmClientImplOverride =
+        agora_rtm_client_impl.RtmClientImplOverride.create(irisMethodChannel);
+    const message = 'hello';
+    final messageUint8List = Uint8List.fromList(utf8.encode(message));
+
+    rtmClientImplOverride.publishBinaryMessage(
+        channelName: '123',
+        message: messageUint8List,
+        length: messageUint8List.length,
+        option: const PublishOptions());
+
+    final methodCall = irisMethodChannel.methodCallQueue[0];
+    final paramsMap = jsonDecode(methodCall.params);
+    expect(paramsMap['length'], messageUint8List.length);
+    expect(methodCall.buffers![0], messageUint8List);
+  });
+}

--- a/test_shard/integration_test_app/test/agora_stream_channel_impl_override_test.dart
+++ b/test_shard/integration_test_app/test/agora_stream_channel_impl_override_test.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import 'dart:typed_data' show Uint8List;
+
+import 'package:agora_rtm/agora_rtm.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:agora_rtm/src/bindings/agora_stream_channel_impl_override.dart'
+    as agora_stream_channel_impl;
+
+import 'fake_iris_method_channel.dart';
+
+void main() {
+  test('StreamChannelImpl.publishTopicMessage', () {
+    FakeIrisMethodChannel irisMethodChannel = FakeIrisMethodChannel();
+    agora_stream_channel_impl.StreamChannelImpl streamChannelImpl =
+        agora_stream_channel_impl.StreamChannelImpl(irisMethodChannel, '123');
+    const message = 'hello';
+    final messageUint8List = Uint8List.fromList(utf8.encode(message));
+
+    streamChannelImpl.publishTopicMessage(
+        topic: '123',
+        message: message,
+        length: 5,
+        option: const TopicMessageOptions());
+
+    final methodCall = irisMethodChannel.methodCallQueue[0];
+    final paramsMap = jsonDecode(methodCall.params);
+    expect(paramsMap['length'], messageUint8List.length);
+    expect(methodCall.buffers![0], messageUint8List);
+  });
+
+  test('StreamChannelImpl.publishBinaryMessage', () {
+    FakeIrisMethodChannel irisMethodChannel = FakeIrisMethodChannel();
+    agora_stream_channel_impl.StreamChannelImpl streamChannelImpl =
+        agora_stream_channel_impl.StreamChannelImpl(irisMethodChannel, '123');
+    const message = 'hello';
+    final messageUint8List = Uint8List.fromList(utf8.encode(message));
+
+    streamChannelImpl.publishBinaryMessage(
+        topic: '123',
+        message: messageUint8List,
+        length: messageUint8List.length,
+        option: const TopicMessageOptions());
+
+    final methodCall = irisMethodChannel.methodCallQueue[0];
+    final paramsMap = jsonDecode(methodCall.params);
+    expect(paramsMap['length'], messageUint8List.length);
+    expect(methodCall.buffers![0], messageUint8List);
+  });
+}

--- a/test_shard/integration_test_app/test/all_mocks.dart
+++ b/test_shard/integration_test_app/test/all_mocks.dart
@@ -14,14 +14,16 @@ import 'package:agora_rtm/src/bindings/gen/agora_stream_channel_impl.dart'
 
 import 'package:agora_rtm/src/impl/rtm_result_handler_impl.dart';
 
+import 'package:iris_method_channel/iris_method_channel.dart';
+
 @GenerateNiceMocks([
   MockSpec<rtm_client_impl_native_binding.RtmClientImplOverride>(),
   MockSpec<rtm_lock_impl_native_binding.RtmLockImpl>(),
   MockSpec<rtm_presence_impl_native_binding.RtmPresenceImpl>(),
   MockSpec<rtm_storage_impl_native_binding.RtmStorageImpl>(),
   MockSpec<stream_channel_impl_native_binding.StreamChannelImpl>(),
-  // RtmResultHandlerImpl
   MockSpec<RtmResultHandlerImpl>(),
+  MockSpec<IrisMethodChannel>(),
 ])
 // ignore: unused_import
 import 'all_mocks.mocks.dart';

--- a/test_shard/integration_test_app/test/all_mocks.mocks.dart
+++ b/test_shard/integration_test_app/test/all_mocks.mocks.dart
@@ -5,6 +5,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i8;
 import 'dart:typed_data' as _i13;
+import 'dart:ui' as _i15;
 
 import 'package:agora_rtm/src/agora_rtm_base.dart' as _i12;
 import 'package:agora_rtm/src/agora_rtm_client.dart' as _i11;
@@ -117,6 +118,37 @@ class _FakeRtmEventHandler_7 extends _i1.SmartFake
 
 class _FakeFuture_8<T1> extends _i1.SmartFake implements _i8.Future<T1> {
   _FakeFuture_8(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeScopedObjects_9 extends _i1.SmartFake implements _i3.ScopedObjects {
+  _FakeScopedObjects_9(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCallApiResult_10 extends _i1.SmartFake implements _i3.CallApiResult {
+  _FakeCallApiResult_10(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeIrisMethodChannelInternal_11 extends _i1.SmartFake
+    implements _i3.IrisMethodChannelInternal {
+  _FakeIrisMethodChannelInternal_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -2249,4 +2281,219 @@ class MockRtmResultHandlerImpl extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+}
+
+/// A class which mocks [IrisMethodChannel].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockIrisMethodChannel extends _i1.Mock implements _i3.IrisMethodChannel {
+  @override
+  _i3.ScopedObjects get scopedEventHandlers => (super.noSuchMethod(
+        Invocation.getter(#scopedEventHandlers),
+        returnValue: _FakeScopedObjects_9(
+          this,
+          Invocation.getter(#scopedEventHandlers),
+        ),
+        returnValueForMissingStub: _FakeScopedObjects_9(
+          this,
+          Invocation.getter(#scopedEventHandlers),
+        ),
+      ) as _i3.ScopedObjects);
+
+  @override
+  _i8.Future<_i3.InitilizationResult?> initilize(
+          List<_i3.InitilizationArgProvider>? args) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #initilize,
+          [args],
+        ),
+        returnValue: _i8.Future<_i3.InitilizationResult?>.value(),
+        returnValueForMissingStub: _i8.Future<_i3.InitilizationResult?>.value(),
+      ) as _i8.Future<_i3.InitilizationResult?>);
+
+  @override
+  _i8.Future<_i3.CallApiResult> invokeMethod(_i3.IrisMethodCall? methodCall) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #invokeMethod,
+          [methodCall],
+        ),
+        returnValue: _i8.Future<_i3.CallApiResult>.value(_FakeCallApiResult_10(
+          this,
+          Invocation.method(
+            #invokeMethod,
+            [methodCall],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i8.Future<_i3.CallApiResult>.value(_FakeCallApiResult_10(
+          this,
+          Invocation.method(
+            #invokeMethod,
+            [methodCall],
+          ),
+        )),
+      ) as _i8.Future<_i3.CallApiResult>);
+
+  @override
+  _i8.Future<List<_i3.CallApiResult>> invokeMethodList(
+          List<_i3.IrisMethodCall>? methodCalls) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #invokeMethodList,
+          [methodCalls],
+        ),
+        returnValue:
+            _i8.Future<List<_i3.CallApiResult>>.value(<_i3.CallApiResult>[]),
+        returnValueForMissingStub:
+            _i8.Future<List<_i3.CallApiResult>>.value(<_i3.CallApiResult>[]),
+      ) as _i8.Future<List<_i3.CallApiResult>>);
+
+  @override
+  _i8.Future<void> dispose() => (super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+
+  @override
+  _i8.Future<_i3.CallApiResult> registerEventHandler(
+    _i3.ScopedEvent? scopedEvent,
+    String? params,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #registerEventHandler,
+          [
+            scopedEvent,
+            params,
+          ],
+        ),
+        returnValue: _i8.Future<_i3.CallApiResult>.value(_FakeCallApiResult_10(
+          this,
+          Invocation.method(
+            #registerEventHandler,
+            [
+              scopedEvent,
+              params,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i8.Future<_i3.CallApiResult>.value(_FakeCallApiResult_10(
+          this,
+          Invocation.method(
+            #registerEventHandler,
+            [
+              scopedEvent,
+              params,
+            ],
+          ),
+        )),
+      ) as _i8.Future<_i3.CallApiResult>);
+
+  @override
+  _i8.Future<_i3.CallApiResult> unregisterEventHandler(
+    _i3.ScopedEvent? scopedEvent,
+    String? params,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #unregisterEventHandler,
+          [
+            scopedEvent,
+            params,
+          ],
+        ),
+        returnValue: _i8.Future<_i3.CallApiResult>.value(_FakeCallApiResult_10(
+          this,
+          Invocation.method(
+            #unregisterEventHandler,
+            [
+              scopedEvent,
+              params,
+            ],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i8.Future<_i3.CallApiResult>.value(_FakeCallApiResult_10(
+          this,
+          Invocation.method(
+            #unregisterEventHandler,
+            [
+              scopedEvent,
+              params,
+            ],
+          ),
+        )),
+      ) as _i8.Future<_i3.CallApiResult>);
+
+  @override
+  _i8.Future<void> unregisterEventHandlers(_i3.TypedScopedKey? scopedKey) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #unregisterEventHandlers,
+          [scopedKey],
+        ),
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+
+  @override
+  int getApiEngineHandle() => (super.noSuchMethod(
+        Invocation.method(
+          #getApiEngineHandle,
+          [],
+        ),
+        returnValue: 0,
+        returnValueForMissingStub: 0,
+      ) as int);
+
+  @override
+  _i15.VoidCallback addHotRestartListener(_i3.HotRestartListener? listener) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addHotRestartListener,
+          [listener],
+        ),
+        returnValue: () {},
+        returnValueForMissingStub: () {},
+      ) as _i15.VoidCallback);
+
+  @override
+  void removeHotRestartListener(_i3.HotRestartListener? listener) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #removeHotRestartListener,
+          [listener],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i3.IrisMethodChannelInternal getIrisMethodChannelInternal() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getIrisMethodChannelInternal,
+          [],
+        ),
+        returnValue: _FakeIrisMethodChannelInternal_11(
+          this,
+          Invocation.method(
+            #getIrisMethodChannelInternal,
+            [],
+          ),
+        ),
+        returnValueForMissingStub: _FakeIrisMethodChannelInternal_11(
+          this,
+          Invocation.method(
+            #getIrisMethodChannelInternal,
+            [],
+          ),
+        ),
+      ) as _i3.IrisMethodChannelInternal);
 }

--- a/test_shard/integration_test_app/test/fake_iris_method_channel.dart
+++ b/test_shard/integration_test_app/test/fake_iris_method_channel.dart
@@ -1,0 +1,13 @@
+import 'package:mockito/mockito.dart';
+import 'package:iris_method_channel/iris_method_channel.dart';
+
+class FakeIrisMethodChannel extends Fake implements IrisMethodChannel {
+  final List<IrisMethodCall> methodCallQueue = [];
+
+  @override
+  Future<CallApiResult> invokeMethod(IrisMethodCall methodCall) async {
+    methodCallQueue.add(methodCall);
+    return CallApiResult(
+        irisReturnCode: 0, data: {'result': 0, 'requestId': 1});
+  }
+}


### PR DESCRIPTION
For example, the `RtmClientImplOverride.publish` redirects to the `publishBinaryMessage` internally, but the `length` still uses the `length` of the string `message`. It should be the length of the `Uint8List.fromList(utf8.encode(message))`.