### PR TITLE
[example] Integrate with agora_rtc_engine

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -59,6 +59,10 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
+    packagingOptions {
+      pickFirst 'lib/**/libaosl.so'
+    }
 }
 
 flutter {

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -39,3 +39,15 @@ post_install do |installer|
     flutter_additional_ios_build_settings(target)
   end
 end
+
+pre_install do |installer|
+  rtm_pod_path = File.join(installer.sandbox.root, 'AgoraRtm')
+  aosl_xcframework_path = File.join(rtm_pod_path, 'aosl.xcframework')
+
+  if File.exist?(aosl_xcframework_path)
+    puts "Deleting aosl.xcframework from #{aosl_xcframework_path}"
+    FileUtils.rm_rf(aosl_xcframework_path)
+  else
+    puts "aosl.xcframework not found, skipping deletion."
+  end
+end

--- a/example/lib/src/rtm_api_demo.dart
+++ b/example/lib/src/rtm_api_demo.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:agora_rtc_engine/agora_rtc_engine.dart';
 import 'package:agora_rtm/agora_rtm.dart';
 import 'package:flutter/material.dart';
 
@@ -44,6 +45,7 @@ class _RtmApiDemoState extends State<RtmApiDemo> {
   RtmChannelType _rtmChannelType = RtmChannelType.message;
 
   late RtmClient _rtmClient;
+  late RtcEngine _rtcEngine;
 
   @override
   void initState() {
@@ -420,6 +422,32 @@ class _RtmApiDemoState extends State<RtmApiDemo> {
                       customType: _rtmClientPublishCustomTypeController.text);
 
                   logSink.log('[PublishResult] errorCode: ${status.errorCode}');
+                }),
+              ],
+            ),
+            _card(
+              [
+                const Text('Work with Agora Rtc Engine'),
+                _button('Init RtcEngine', () async {
+                  _rtcEngine = createAgoraRtcEngine();
+                  await _rtcEngine
+                      .initialize(RtcEngineContext(appId: config.appId));
+
+                  logSink.log('RtcEngine.initialize success');
+                }),
+                _button('Join Channel', () async {
+                  await _rtcEngine.joinChannel(
+                      token: '',
+                      channelId: config.channelId,
+                      uid: 0,
+                      options: const ChannelMediaOptions());
+
+                  logSink.log('RtcEngine.joinChannel success');
+                }),
+                _button('Release', () async {
+                  await _rtcEngine.release();
+
+                  logSink.log('RtcEngine.release success');
                 }),
               ],
             ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -26,7 +26,14 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
+  agora_rtc_engine: ^6.3.2
+
   flutter_riverpod: ^1.0.0
+
+dependency_overrides: 
+  # When using agora_rtm 2.2.2 with agora_rtc_engine 6.3.2, we need to override the iris_method_channel to 2.2.2, 
+  # the issue will be fixed with the next release of agora_rtc_engine
+  iris_method_channel: ^2.2.2 
 
 dev_dependencies:
   integration_test:


### PR DESCRIPTION
Some customers encountered issues when integrating with `agora_rtc_engine`. To address this, additional configurations are required during the integration process.