### PR TITLE
Update iris_method_channel constraint to >= 2.2.2 for improved compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   ffi: '>=1.1.2'
   async: '>=2.8.2'
   meta: '>=1.7.0'
-  iris_method_channel: ^2.2.2
+  iris_method_channel: '>=2.2.2'
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Update the `iris_method_channel` constraint to >= 2.2.2, allowing greater flexibility for compatibility with `iris_method_channel` 2.x.x and even future 3.x.x versions