### PR TITLE
Move static `fromValue()` to enum and deprecate old

### DIFF
--- a/lib/src/agora_rtm_base.dart
+++ b/lib/src/agora_rtm_base.dart
@@ -23,10 +23,17 @@ enum RtmLinkState {
 
   @JsonValue(5)
   failed,
+  ;
+
+  /// @nodoc
+  static RtmLinkState fromValue(int value) {
+    return $enumDecode(_$RtmLinkStateEnumMap, value);
+  }
 }
 
 extension RtmLinkStateExt on RtmLinkState {
   /// @nodoc
+  @Deprecated('Use RtmLinkState.fromValue instead')
   static RtmLinkState fromValue(int value) {
     return $enumDecode(_$RtmLinkStateEnumMap, value);
   }
@@ -68,10 +75,17 @@ enum RtmLinkOperation {
 
   @JsonValue(9)
   networkChange,
+  ;
+
+  /// @nodoc
+  static RtmLinkOperation fromValue(int value) {
+    return $enumDecode(_$RtmLinkOperationEnumMap, value);
+  }
 }
 
 extension RtmLinkOperationExt on RtmLinkOperation {
   /// @nodoc
+  @Deprecated('Use RtmLinkOperation.fromValue instead')
   static RtmLinkOperation fromValue(int value) {
     return $enumDecode(_$RtmLinkOperationEnumMap, value);
   }
@@ -92,10 +106,17 @@ enum RtmServiceType {
 
   @JsonValue(0x00000002)
   stream,
+  ;
+
+  /// @nodoc
+  static RtmServiceType fromValue(int value) {
+    return $enumDecode(_$RtmServiceTypeEnumMap, value);
+  }
 }
 
 extension RtmServiceTypeExt on RtmServiceType {
   /// @nodoc
+  @Deprecated('Use RtmServiceType.fromValue instead')
   static RtmServiceType fromValue(int value) {
     return $enumDecode(_$RtmServiceTypeEnumMap, value);
   }
@@ -113,10 +134,17 @@ enum RtmProtocolType {
 
   @JsonValue(1)
   tcpOnly,
+  ;
+
+  /// @nodoc
+  static RtmProtocolType fromValue(int value) {
+    return $enumDecode(_$RtmProtocolTypeEnumMap, value);
+  }
 }
 
 extension RtmProtocolTypeExt on RtmProtocolType {
   /// @nodoc
+  @Deprecated('Use RtmProtocolType.fromValue instead')
   static RtmProtocolType fromValue(int value) {
     return $enumDecode(_$RtmProtocolTypeEnumMap, value);
   }
@@ -149,10 +177,17 @@ enum RtmAreaCode {
 
   @JsonValue((0xFFFFFFFF))
   glob,
+  ;
+
+  /// @nodoc
+  static RtmAreaCode fromValue(int value) {
+    return $enumDecode(_$RtmAreaCodeEnumMap, value);
+  }
 }
 
 extension RtmAreaCodeExt on RtmAreaCode {
   /// @nodoc
+  @Deprecated('Use RtmAreaCode.fromValue instead')
   static RtmAreaCode fromValue(int value) {
     return $enumDecode(_$RtmAreaCodeEnumMap, value);
   }
@@ -179,10 +214,17 @@ enum RtmLogLevel {
 
   @JsonValue(0x0008)
   fatal,
+  ;
+
+  /// @nodoc
+  static RtmLogLevel fromValue(int value) {
+    return $enumDecode(_$RtmLogLevelEnumMap, value);
+  }
 }
 
 extension RtmLogLevelExt on RtmLogLevel {
   /// @nodoc
+  @Deprecated('Use RtmLogLevel.fromValue instead')
   static RtmLogLevel fromValue(int value) {
     return $enumDecode(_$RtmLogLevelEnumMap, value);
   }
@@ -203,10 +245,17 @@ enum RtmEncryptionMode {
 
   @JsonValue(2)
   aes256Gcm,
+  ;
+
+  /// @nodoc
+  static RtmEncryptionMode fromValue(int value) {
+    return $enumDecode(_$RtmEncryptionModeEnumMap, value);
+  }
 }
 
 extension RtmEncryptionModeExt on RtmEncryptionMode {
   /// @nodoc
+  @Deprecated('Use RtmEncryptionMode.fromValue instead')
   static RtmEncryptionMode fromValue(int value) {
     return $enumDecode(_$RtmEncryptionModeEnumMap, value);
   }
@@ -521,10 +570,17 @@ enum RtmErrorCode {
 
   @JsonValue(-14009)
   lockNotAvailable,
+  ;
+
+  /// @nodoc
+  static RtmErrorCode fromValue(int value) {
+    return $enumDecode(_$RtmErrorCodeEnumMap, value);
+  }
 }
 
 extension RtmErrorCodeExt on RtmErrorCode {
   /// @nodoc
+  @Deprecated('Use RtmErrorCode.fromValue instead')
   static RtmErrorCode fromValue(int value) {
     return $enumDecode(_$RtmErrorCodeEnumMap, value);
   }
@@ -551,10 +607,17 @@ enum RtmConnectionState {
 
   @JsonValue(5)
   failed,
+  ;
+
+  /// @nodoc
+  static RtmConnectionState fromValue(int value) {
+    return $enumDecode(_$RtmConnectionStateEnumMap, value);
+  }
 }
 
 extension RtmConnectionStateExt on RtmConnectionState {
   /// @nodoc
+  @Deprecated('Use RtmConnectionState.fromValue instead')
   static RtmConnectionState fromValue(int value) {
     return $enumDecode(_$RtmConnectionStateEnumMap, value);
   }
@@ -650,10 +713,17 @@ enum RtmConnectionChangeReason {
 
   @JsonValue(10003)
   presenceNotReady,
+  ;
+
+  /// @nodoc
+  static RtmConnectionChangeReason fromValue(int value) {
+    return $enumDecode(_$RtmConnectionChangeReasonEnumMap, value);
+  }
 }
 
 extension RtmConnectionChangeReasonExt on RtmConnectionChangeReason {
   /// @nodoc
+  @Deprecated('Use RtmConnectionChangeReason.fromValue instead')
   static RtmConnectionChangeReason fromValue(int value) {
     return $enumDecode(_$RtmConnectionChangeReasonEnumMap, value);
   }
@@ -677,10 +747,17 @@ enum RtmChannelType {
 
   @JsonValue(3)
   user,
+  ;
+
+  /// @nodoc
+  static RtmChannelType fromValue(int value) {
+    return $enumDecode(_$RtmChannelTypeEnumMap, value);
+  }
 }
 
 extension RtmChannelTypeExt on RtmChannelType {
   /// @nodoc
+  @Deprecated('Use RtmChannelType.fromValue instead')
   static RtmChannelType fromValue(int value) {
     return $enumDecode(_$RtmChannelTypeEnumMap, value);
   }
@@ -698,10 +775,17 @@ enum RtmMessageType {
 
   @JsonValue(1)
   string,
+  ;
+
+  /// @nodoc
+  static RtmMessageType fromValue(int value) {
+    return $enumDecode(_$RtmMessageTypeEnumMap, value);
+  }
 }
 
 extension RtmMessageTypeExt on RtmMessageType {
   /// @nodoc
+  @Deprecated('Use RtmMessageType.fromValue instead')
   static RtmMessageType fromValue(int value) {
     return $enumDecode(_$RtmMessageTypeEnumMap, value);
   }
@@ -722,10 +806,17 @@ enum RtmStorageType {
 
   @JsonValue(2)
   channel,
+  ;
+
+  /// @nodoc
+  static RtmStorageType fromValue(int value) {
+    return $enumDecode(_$RtmStorageTypeEnumMap, value);
+  }
 }
 
 extension RtmStorageTypeExt on RtmStorageType {
   /// @nodoc
+  @Deprecated('Use RtmStorageType.fromValue instead')
   static RtmStorageType fromValue(int value) {
     return $enumDecode(_$RtmStorageTypeEnumMap, value);
   }
@@ -752,10 +843,17 @@ enum RtmStorageEventType {
 
   @JsonValue(4)
   remove,
+  ;
+
+  /// @nodoc
+  static RtmStorageEventType fromValue(int value) {
+    return $enumDecode(_$RtmStorageEventTypeEnumMap, value);
+  }
 }
 
 extension RtmStorageEventTypeExt on RtmStorageEventType {
   /// @nodoc
+  @Deprecated('Use RtmStorageEventType.fromValue instead')
   static RtmStorageEventType fromValue(int value) {
     return $enumDecode(_$RtmStorageEventTypeEnumMap, value);
   }
@@ -788,10 +886,17 @@ enum RtmLockEventType {
 
   @JsonValue(6)
   lockExpired,
+  ;
+
+  /// @nodoc
+  static RtmLockEventType fromValue(int value) {
+    return $enumDecode(_$RtmLockEventTypeEnumMap, value);
+  }
 }
 
 extension RtmLockEventTypeExt on RtmLockEventType {
   /// @nodoc
+  @Deprecated('Use RtmLockEventType.fromValue instead')
   static RtmLockEventType fromValue(int value) {
     return $enumDecode(_$RtmLockEventTypeEnumMap, value);
   }
@@ -812,10 +917,17 @@ enum RtmProxyType {
 
   @JsonValue(2)
   cloudTcp,
+  ;
+
+  /// @nodoc
+  static RtmProxyType fromValue(int value) {
+    return $enumDecode(_$RtmProxyTypeEnumMap, value);
+  }
 }
 
 extension RtmProxyTypeExt on RtmProxyType {
   /// @nodoc
+  @Deprecated('Use RtmProxyType.fromValue instead')
   static RtmProxyType fromValue(int value) {
     return $enumDecode(_$RtmProxyTypeEnumMap, value);
   }
@@ -839,10 +951,17 @@ enum RtmTopicEventType {
 
   @JsonValue(3)
   remoteLeaveTopic,
+  ;
+
+  /// @nodoc
+  static RtmTopicEventType fromValue(int value) {
+    return $enumDecode(_$RtmTopicEventTypeEnumMap, value);
+  }
 }
 
 extension RtmTopicEventTypeExt on RtmTopicEventType {
   /// @nodoc
+  @Deprecated('Use RtmTopicEventType.fromValue instead')
   static RtmTopicEventType fromValue(int value) {
     return $enumDecode(_$RtmTopicEventTypeEnumMap, value);
   }
@@ -878,10 +997,17 @@ enum RtmPresenceEventType {
 
   @JsonValue(7)
   errorOutOfService,
+  ;
+
+  /// @nodoc
+  static RtmPresenceEventType fromValue(int value) {
+    return $enumDecode(_$RtmPresenceEventTypeEnumMap, value);
+  }
 }
 
 extension RtmPresenceEventTypeExt on RtmPresenceEventType {
   /// @nodoc
+  @Deprecated('Use RtmPresenceEventType.fromValue instead')
   static RtmPresenceEventType fromValue(int value) {
     return $enumDecode(_$RtmPresenceEventTypeEnumMap, value);
   }

--- a/lib/src/agora_stream_channel.dart
+++ b/lib/src/agora_stream_channel.dart
@@ -8,10 +8,17 @@ enum RtmMessageQos {
 
   @JsonValue(1)
   ordered,
+  ;
+
+  /// @nodoc
+  static RtmMessageQos fromValue(int value) {
+    return $enumDecode(_$RtmMessageQosEnumMap, value);
+  }
 }
 
 extension RtmMessageQosExt on RtmMessageQos {
   /// @nodoc
+  @Deprecated('Use RtmMessageQos.fromValue instead')
   static RtmMessageQos fromValue(int value) {
     return $enumDecode(_$RtmMessageQosEnumMap, value);
   }
@@ -35,10 +42,17 @@ enum RtmMessagePriority {
 
   @JsonValue(8)
   low,
+  ;
+
+  /// @nodoc
+  static RtmMessagePriority fromValue(int value) {
+    return $enumDecode(_$RtmMessagePriorityEnumMap, value);
+  }
 }
 
 extension RtmMessagePriorityExt on RtmMessagePriority {
   /// @nodoc
+  @Deprecated('Use RtmMessagePriority.fromValue instead')
   static RtmMessagePriority fromValue(int value) {
     return $enumDecode(_$RtmMessagePriorityEnumMap, value);
   }

--- a/test_shard/integration_test_app/test/agora_rtm_base_test.dart
+++ b/test_shard/integration_test_app/test/agora_rtm_base_test.dart
@@ -1,0 +1,107 @@
+import 'package:agora_rtm/agora_rtm.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('static fromValue() with enums', () {
+    test('RtmLinkState', () {
+      for (final e in RtmLinkState.values) {
+        expect(RtmLinkState.fromValue(e.value()), e);
+      }
+    });
+    test('RtmLinkOperation', () {
+      for (final e in RtmLinkOperation.values) {
+        expect(RtmLinkOperation.fromValue(e.value()), e);
+      }
+    });
+    test('RtmServiceType', () {
+      for (final e in RtmServiceType.values) {
+        expect(RtmServiceType.fromValue(e.value()), e);
+      }
+    });
+    test('RtmProtocolType', () {
+      for (final e in RtmProtocolType.values) {
+        expect(RtmProtocolType.fromValue(e.value()), e);
+      }
+    });
+    test('RtmAreaCode', () {
+      for (final e in RtmAreaCode.values) {
+        expect(RtmAreaCode.fromValue(e.value()), e);
+      }
+    });
+    test('RtmLogLevel', () {
+      for (final e in RtmLogLevel.values) {
+        expect(RtmLogLevel.fromValue(e.value()), e);
+      }
+    });
+    test('RtmEncryptionMode', () {
+      for (final e in RtmEncryptionMode.values) {
+        expect(RtmEncryptionMode.fromValue(e.value()), e);
+      }
+    });
+    test('RtmErrorCode', () {
+      for (final e in RtmErrorCode.values) {
+        expect(RtmErrorCode.fromValue(e.value()), e);
+      }
+    });
+    test('RtmConnectionState', () {
+      for (final e in RtmConnectionState.values) {
+        expect(RtmConnectionState.fromValue(e.value()), e);
+      }
+    });
+    test('RtmConnectionChangeReason', () {
+      for (final e in RtmConnectionChangeReason.values) {
+        expect(RtmConnectionChangeReason.fromValue(e.value()), e);
+      }
+    });
+    test('RtmChannelType', () {
+      for (final e in RtmChannelType.values) {
+        expect(RtmChannelType.fromValue(e.value()), e);
+      }
+    });
+    test('RtmMessageType', () {
+      for (final e in RtmMessageType.values) {
+        expect(RtmMessageType.fromValue(e.value()), e);
+      }
+    });
+    test('RtmStorageType', () {
+      for (final e in RtmStorageType.values) {
+        expect(RtmStorageType.fromValue(e.value()), e);
+      }
+    });
+    test('RtmStorageEventType', () {
+      for (final e in RtmStorageEventType.values) {
+        expect(RtmStorageEventType.fromValue(e.value()), e);
+      }
+    });
+    test('RtmLockEventType', () {
+      for (final e in RtmLockEventType.values) {
+        expect(RtmLockEventType.fromValue(e.value()), e);
+      }
+    });
+    test('RtmProxyType', () {
+      for (final e in RtmProxyType.values) {
+        expect(RtmProxyType.fromValue(e.value()), e);
+      }
+    });
+    test('RtmTopicEventType', () {
+      for (final e in RtmTopicEventType.values) {
+        expect(RtmTopicEventType.fromValue(e.value()), e);
+      }
+    });
+    test('RtmPresenceEventType', () {
+      for (final e in RtmPresenceEventType.values) {
+        expect(RtmPresenceEventType.fromValue(e.value()), e);
+      }
+    });
+    test('RtmMessageQos', () {
+      for (final e in RtmMessageQos.values) {
+        expect(RtmMessageQos.fromValue(e.value()), e);
+      }
+    });
+    test('RtmMessageQos', () {
+      for (final e in RtmMessageQos.values) {
+        expect(RtmMessageQos.fromValue(e.value()), e);
+      }
+    });
+  });
+}


### PR DESCRIPTION
`static` methods are for classes, so static methods on extensions create `ExtensionType.staticMethod` rather than `Type.staticMethod`.

The request corrects all usages and deprecates all previous methods.

EDIT: Enhanced enums are supported since Dart 2.17, our SDK constraint is `^3.0.0`.