### PR TITLE
Fix `IrisMethodChannel.wrapRtmStatus`

### DIFF
--- a/lib/src/impl/extensions.dart
+++ b/lib/src/impl/extensions.dart
@@ -1,27 +1,30 @@
 import 'dart:async';
 
-import 'package:agora_rtm/src/agora_rtm_client_ext.dart';
-import 'package:agora_rtm/src/binding_forward_export.dart';
 import 'package:iris_method_channel/iris_method_channel.dart';
+
+import '/src/binding_forward_export.dart';
 
 extension IrisMethodChannelExt on IrisMethodChannel {
   Future<RtmStatus> wrapRtmStatus(
-      int nativeReturnCode, String operation) async {
+    int nativeReturnCode,
+    String operation,
+  ) async {
     if (nativeReturnCode == 0) {
-      return Future.sync(() => RtmStatus.success(operation: operation));
+      return Future.value(RtmStatus.success(operation: operation));
     }
 
     final param = {'error_code': nativeReturnCode};
-    final callApiResult = await invokeMethod(IrisMethodCall(
-        'GetIrisRtmErrorReason', jsonEncode(param),
-        buffers: null));
+    final callApiResult = await invokeMethod(
+      IrisMethodCall('GetIrisRtmErrorReason', jsonEncode(param), buffers: null),
+    );
 
     final rm = callApiResult.data;
-    final result = rm['result'];
+    final result = rm['result'].toString();
 
     return RtmStatus.error(
-        errorCode: nativeReturnCode.toString(),
-        operation: operation,
-        reason: result);
+      errorCode: nativeReturnCode.toString(),
+      operation: operation,
+      reason: result,
+    );
   }
 }


### PR DESCRIPTION
From our crashlytics with iOS 18.3:

```console
type 'int' is not a subtype of type 'String'
#0      IrisMethodChannelExt.wrapRtmStatus (package:agora_rtm/src/impl/extensions.dart:25)
<asynchronous suspension>
#1      RtmClientImpl.unsubscribe (package:agora_rtm/src/impl/gen/agora_rtm_client_impl.dart:183)
```
