### PR TITLE
Fix `RtmClientLogoutJson.fromJson`

### DIFF
--- a/lib/src/bindings/gen/call_api_impl_params_json.dart
+++ b/lib/src/bindings/gen/call_api_impl_params_json.dart
@@ -22,7 +22,7 @@ class RtmClientLoginJson {
 class RtmClientLogoutJson {
   const RtmClientLogoutJson(this.requestId);
 
-  @JsonKey(name: 'requestId')
+  @JsonKey(name: 'requestId', defaultValue: 0)
   final int requestId;
 
   factory RtmClientLogoutJson.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/bindings/gen/call_api_impl_params_json.g.dart
+++ b/lib/src/bindings/gen/call_api_impl_params_json.g.dart
@@ -18,7 +18,7 @@ Map<String, dynamic> _$RtmClientLoginJsonToJson(RtmClientLoginJson instance) =>
 
 RtmClientLogoutJson _$RtmClientLogoutJsonFromJson(Map<String, dynamic> json) =>
     RtmClientLogoutJson(
-      (json['requestId'] as num).toInt(),
+      (json['requestId'] as num?)?.toInt() ?? 0,
     );
 
 Map<String, dynamic> _$RtmClientLogoutJsonToJson(


### PR DESCRIPTION
From our crashlytics with iOS 18.4:

```console
type 'Null' is not a subtype of type 'num' in type cast
#0      _$RtmClientLogoutJsonFromJson (package:agora_rtm/src/bindings/gen/call_api_impl_params_json.g.dart:21)
#1      new RtmClientLogoutJson.fromJson (package:agora_rtm/src/bindings/gen/call_api_impl_params_json.dart:29)
#2      RtmClientImpl.logout (package:agora_rtm/src/bindings/gen/agora_rtm_client_impl.dart:74)
<asynchronous suspension>
#3      RtmClientImpl.logout (package:agora_rtm/src/impl/gen/agora_rtm_client_impl.dart:71)
```